### PR TITLE
GIG-2183: Offline authentication fix

### DIFF
--- a/lmcommon/auth/identity.py
+++ b/lmcommon/auth/identity.py
@@ -154,9 +154,11 @@ class IdentityManager(metaclass=abc.ABCMeta):
         Returns:
             dict
         """
-        key_path = "/mnt/share"
-        key_file = os.path.join(key_path, "jwks.json")
+        key_path = "/mnt/gigantum/.labmanager/identity"
+        if not os.path.exists(key_path):
+            os.makedirs(key_path)
 
+        key_file = os.path.join(key_path, "jwks.json")
         # Check for local cached key data
         if os.path.exists(key_file):
             with open(key_file, 'rt') as jwk_file:

--- a/lmcommon/auth/identity.py
+++ b/lmcommon/auth/identity.py
@@ -154,7 +154,7 @@ class IdentityManager(metaclass=abc.ABCMeta):
         Returns:
             dict
         """
-        key_path = "/mnt/gigantum/.labmanager/identity"
+        key_path = os.path.join(self.config.config['git']['working_directory'], '.labmanager', 'identity')
         if not os.path.exists(key_path):
             os.makedirs(key_path)
 

--- a/lmcommon/auth/local.py
+++ b/lmcommon/auth/local.py
@@ -132,6 +132,9 @@ class LocalIdentityManager(IdentityManager):
         data_file = os.path.join(self.auth_dir, 'cached_id_jwt')
         if os.path.exists(data_file):
             os.remove(data_file)
+        data_file = os.path.join(self.auth_dir, 'jwks.json')
+        if os.path.exists(data_file):
+            os.remove(data_file)
 
         self.user = None
         self.rsa_key = None

--- a/lmcommon/auth/tests/test_local.py
+++ b/lmcommon/auth/tests/test_local.py
@@ -99,10 +99,12 @@ class TestIdentityLocal(object):
         assert os.path.exists(os.path.join(mgr.auth_dir, 'cached_id_jwt')) is False
         mgr._save_user(mock_config_file_with_auth[1]['id_token'])
         assert os.path.exists(os.path.join(mgr.auth_dir, 'cached_id_jwt')) is True
+        assert os.path.exists(os.path.join(mgr.auth_dir, 'jwks.json')) is True
 
         # Load User
         mgr.logout()
         assert os.path.exists(os.path.join(mgr.auth_dir, 'cached_id_jwt')) is False
+        assert os.path.exists(os.path.join(mgr.auth_dir, 'jwks.json')) is False
         assert mgr.user is None
         assert mgr.rsa_key is None
         assert mgr._load_user(None) is None

--- a/lmcommon/environment/tests/test_conda.py
+++ b/lmcommon/environment/tests/test_conda.py
@@ -100,7 +100,7 @@ class TestConda3PackageManager(object):
 
         # numpy is a non-installed package
         result = mrg.latest_version("numpy", lb, username)
-        assert result == '1.15.0'
+        assert result == '1.15.1'
 
     @pytest.mark.skipif(skip_clause, reason=skip_msg)
     def test_latest_versions(self, build_lb_image_for_env_conda):
@@ -111,7 +111,7 @@ class TestConda3PackageManager(object):
         pkgs = ["numpy", "requests", "matplotlib"]
         result = mrg.latest_versions(pkgs, lb, username)
 
-        assert result[0] == '1.15.0'  # Numpy
+        assert result[0] == '1.15.1'  # Numpy
         assert result[1] == REQUESTS_LATEST_VERSION  # Requests
         assert result[2] == '2.2.3'  # Matplotlib
 
@@ -237,7 +237,7 @@ class TestConda3PackageManager(object):
         assert result[0].error is False
 
         assert result[1].package == "plotly"
-        assert result[1].version == "3.1.1"
+        assert result[1].version == "3.2.0"
         assert result[1].error is False
 
 
@@ -251,7 +251,7 @@ class TestConda2PackageManager(object):
         pkgs = ["numpy", "requests"]
         result = mrg.latest_versions(pkgs, lb, username)
 
-        assert result[0] == '1.15.0'  # Numpy
+        assert result[0] == '1.15.1'  # Numpy
         assert result[1] == '2.19.1'  # Requests
 
     @pytest.mark.skipif(skip_clause, reason=skip_msg)
@@ -299,5 +299,5 @@ class TestConda2PackageManager(object):
         assert result[0].error is False
 
         assert result[1].package == "plotly"
-        assert result[1].version == "3.1.1"
+        assert result[1].version == "3.2.0"
         assert result[1].error is False

--- a/lmcommon/environment/tests/test_pip.py
+++ b/lmcommon/environment/tests/test_pip.py
@@ -55,7 +55,7 @@ class TestPipPackageManager(object):
         username = build_lb_image_for_env[1]
         result = mrg.latest_version("gigantum", lb, username)
 
-        assert result == "0.11"
+        assert result == "0.12"
 
     def test_latest_versions(self, build_lb_image_for_env):
         """Test latest_version command"""
@@ -64,7 +64,7 @@ class TestPipPackageManager(object):
         username = build_lb_image_for_env[1]
         gig_res, req_res = mrg.latest_versions(["gigantum", "requests"], lb, username)
 
-        assert gig_res == "0.11"
+        assert gig_res == "0.12"
         assert req_res.startswith('2.')
 
     def test_list_installed_packages(self, build_lb_image_for_env):
@@ -180,5 +180,5 @@ class TestPipPackageManager(object):
         assert result[0].error is False
 
         assert result[1].package == "plotly"
-        assert result[1].version == '3.1.1'
+        assert result[1].version == '3.2.0'
         assert result[1].error is False


### PR DESCRIPTION
Fix bug with offline login caused by caching the jwks public key in a location that gets cleared on container start. This meant that if you disconnected from the internet after the container was up to test this feature appeared to be working, but if you started the container while internet was off the app presented the login screen.